### PR TITLE
Remove unnecessary unaligned reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
   trivial_numeric_casts,
   type_alias_bounds,
   tyvar_behind_raw_pointer,
-  unaligned_references,
   unconditional_recursion,
   unreachable_code,
   unreachable_patterns,


### PR DESCRIPTION
Remove check that is now standard